### PR TITLE
Update required zmq version to 4.3.2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class CppZmqConan(ConanFile):
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     no_copy_source = True
-    requires = "zmq/4.2.5@bincrafters/stable"
+    requires = "zmq/4.3.2@bincrafters/stable"
 
     @property
     def _source_subfolder(self):


### PR DESCRIPTION
The previous zmq/4.2.5@bincrafters/stable requirement was failing due to an unavailable version of libsodium (1.0.16).

I was getting the error on macOS.